### PR TITLE
Mark tasks as not done

### DIFF
--- a/src/main/java/jarvis/logic/commands/MarkTaskCommand.java
+++ b/src/main/java/jarvis/logic/commands/MarkTaskCommand.java
@@ -42,6 +42,7 @@ public class MarkTaskCommand extends Command {
 
         Task taskToMark = lastShownList.get(targetIndex.getZeroBased());
         taskToMark.markAsDone();
+        model.setTask(taskToMark, taskToMark);
         model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
         return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, taskToMark));
     }

--- a/src/main/java/jarvis/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/jarvis/logic/commands/UnmarkTaskCommand.java
@@ -1,0 +1,59 @@
+package jarvis.logic.commands;
+
+import static jarvis.model.Model.PREDICATE_SHOW_ALL_TASKS;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import jarvis.commons.core.Messages;
+import jarvis.commons.core.index.Index;
+import jarvis.logic.commands.exceptions.CommandException;
+import jarvis.model.Model;
+import jarvis.model.Task;
+
+/**
+ * Marks a task as not done. The task is identified using its displayed index from the task book.
+ */
+public class UnmarkTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "unmarktask";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Marks a task as not done."
+            + "The task is identified by the index number used in the displayed task list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_MARK_TASK_SUCCESS = "Marked task as not done: %1$s";
+
+    private final Index targetIndex;
+
+    public UnmarkTaskCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Task> lastShownList = model.getFilteredTaskList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        Task taskToMark = lastShownList.get(targetIndex.getZeroBased());
+        taskToMark.markAsNotDone();
+        model.setTask(taskToMark, taskToMark);
+        model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
+        return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, taskToMark));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof UnmarkTaskCommand // instanceof handles nulls
+                && targetIndex.equals(((UnmarkTaskCommand) other).targetIndex));
+        // state check
+    }
+}
+

--- a/src/main/java/jarvis/logic/commands/UnmarkTaskCommand.java
+++ b/src/main/java/jarvis/logic/commands/UnmarkTaskCommand.java
@@ -24,7 +24,7 @@ public class UnmarkTaskCommand extends Command {
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_MARK_TASK_SUCCESS = "Marked task as not done: %1$s";
+    public static final String MESSAGE_UNMARK_TASK_SUCCESS = "Marked task as not done: %1$s";
 
     private final Index targetIndex;
 
@@ -41,11 +41,11 @@ public class UnmarkTaskCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
-        Task taskToMark = lastShownList.get(targetIndex.getZeroBased());
-        taskToMark.markAsNotDone();
-        model.setTask(taskToMark, taskToMark);
+        Task taskToUnmark = lastShownList.get(targetIndex.getZeroBased());
+        taskToUnmark.markAsNotDone();
+        model.setTask(taskToUnmark, taskToUnmark);
         model.updateFilteredTaskList(PREDICATE_SHOW_ALL_TASKS);
-        return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, taskToMark));
+        return new CommandResult(String.format(MESSAGE_UNMARK_TASK_SUCCESS, taskToUnmark));
     }
 
     @Override

--- a/src/main/java/jarvis/logic/parser/JarvisParser.java
+++ b/src/main/java/jarvis/logic/parser/JarvisParser.java
@@ -18,6 +18,7 @@ import jarvis.logic.commands.FindStudentCommand;
 import jarvis.logic.commands.HelpCommand;
 import jarvis.logic.commands.ListStudentCommand;
 import jarvis.logic.commands.MarkTaskCommand;
+import jarvis.logic.commands.UnmarkTaskCommand;
 import jarvis.logic.parser.exceptions.ParseException;
 
 /**
@@ -73,6 +74,9 @@ public class JarvisParser {
 
         case MarkTaskCommand.COMMAND_WORD:
             return new MarkTaskCommandParser().parse(arguments);
+
+        case UnmarkTaskCommand.COMMAND_WORD:
+            return new UnmarkTaskCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/jarvis/logic/parser/UnmarkTaskCommandParser.java
+++ b/src/main/java/jarvis/logic/parser/UnmarkTaskCommandParser.java
@@ -1,0 +1,29 @@
+package jarvis.logic.parser;
+
+import static jarvis.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import jarvis.commons.core.index.Index;
+import jarvis.logic.commands.UnmarkTaskCommand;
+import jarvis.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new UnmarkTaskCommand object
+ */
+public class UnmarkTaskCommandParser implements Parser<UnmarkTaskCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnmarkTaskCommand
+     * and returns an UnmarkTaskCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnmarkTaskCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new UnmarkTaskCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkTaskCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}
+


### PR DESCRIPTION
- Implement `unmarktask` command
- Fix bug where marked task was not immediately displayed in the UI

Closes #5, Fixes #73