### PR TITLE
Improve Ui to highlight timing conflicts between lessons

### DIFF
--- a/src/main/java/jarvis/logic/LogicManager.java
+++ b/src/main/java/jarvis/logic/LogicManager.java
@@ -2,6 +2,7 @@ package jarvis.logic;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.logging.Logger;
 
 import jarvis.commons.core.GuiSettings;
@@ -44,6 +45,15 @@ public class LogicManager implements Logic {
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
+
+        model.updateFilteredLessonList(Model.PREDICATE_SHOW_ALL_LESSONS);
+        List<Lesson> allLessonList = model.getFilteredLessonList();
+        for (Lesson l : allLessonList) {
+            if (l.hasTimingConflict()) {
+                l.unmarkClash();
+                model.setLesson(l, l);
+            }
+        }
 
         CommandResult commandResult;
         Command command = jarvisParser.parseCommand(commandText);

--- a/src/main/java/jarvis/logic/commands/AddConsultCommand.java
+++ b/src/main/java/jarvis/logic/commands/AddConsultCommand.java
@@ -9,14 +9,16 @@ import static jarvis.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static jarvis.logic.parser.CliSyntax.PREFIX_STUDENT_INDEX;
 import static java.util.Objects.requireNonNull;
 
-import java.util.HashSet;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import jarvis.commons.core.Messages;
 import jarvis.commons.core.index.Index;
 import jarvis.logic.commands.exceptions.CommandException;
 import jarvis.model.Consult;
+import jarvis.model.Lesson;
 import jarvis.model.LessonDesc;
 import jarvis.model.Model;
 import jarvis.model.Student;
@@ -71,8 +73,10 @@ public class AddConsultCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Student> lastShownList = model.getFilteredStudentList();
+        model.updateFilteredLessonList(Model.PREDICATE_SHOW_ALL_LESSONS);
+        List<Lesson> allLessonList = model.getFilteredLessonList();
 
-        Set<Student> studentSet = new HashSet<>();
+        Set<Student> studentSet = new TreeSet<>(Comparator.comparing(s -> s.getName().toString()));
         for (Index studentIndex : studentIndexSet) {
             if (studentIndex.getZeroBased() >= lastShownList.size()) {
                 throw new CommandException(Messages.MESSAGE_INVALID_STUDENT_DISPLAYED_INDEX);
@@ -86,6 +90,13 @@ public class AddConsultCommand extends Command {
         if (model.hasLesson(consultToAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_CONSULT);
         } else if (model.hasPeriodClash(consultToAdd)) {
+            allLessonList.stream().filter(consultToAdd::hasTimingConflict).forEach(Lesson::markClash);
+            // Update for JavaFX
+            for (Lesson l : allLessonList) {
+                if (l.hasTimingConflict()) {
+                    model.setLesson(l, l);
+                }
+            }
             throw new CommandException(MESSAGE_TIME_PERIOD_CLASH);
         }
 

--- a/src/main/java/jarvis/logic/commands/AddStudioCommand.java
+++ b/src/main/java/jarvis/logic/commands/AddStudioCommand.java
@@ -10,6 +10,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import jarvis.logic.commands.exceptions.CommandException;
+import jarvis.model.Lesson;
 import jarvis.model.LessonDesc;
 import jarvis.model.Model;
 import jarvis.model.Student;
@@ -66,9 +67,17 @@ public class AddStudioCommand extends Command {
         if (model.hasLesson(studioToAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_STUDIO);
         } else if (model.hasPeriodClash(studioToAdd)) {
+            model.updateFilteredLessonList(Model.PREDICATE_SHOW_ALL_LESSONS);
+            List<Lesson> allLessonList = model.getFilteredLessonList();
+            allLessonList.stream().filter(studioToAdd::hasTimingConflict).forEach(Lesson::markClash);
+            // Update for JavaFX
+            for (Lesson l : allLessonList) {
+                if (l.hasTimingConflict()) {
+                    model.setLesson(l, l);
+                }
+            }
             throw new CommandException(MESSAGE_TIME_PERIOD_CLASH);
         }
-
         model.addLesson(studioToAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, studioToAdd));
     }

--- a/src/main/java/jarvis/model/Lesson.java
+++ b/src/main/java/jarvis/model/Lesson.java
@@ -30,6 +30,7 @@ public abstract class Lesson {
     private final LessonAttendance attendance;
     private final LessonNotes notes;
     private boolean isCompleted = false;
+    private boolean hasClash = false;
 
     /**
      * Every field must be present and not null.
@@ -50,6 +51,10 @@ public abstract class Lesson {
 
     public LocalDateTime endDateTime() {
         return timePeriod.getEnd();
+    }
+
+    public boolean hasTimingConflict() {
+        return hasClash;
     }
 
     public boolean hasTimingConflict(Lesson other) {
@@ -149,5 +154,13 @@ public abstract class Lesson {
 
     public String deleteStudentNote(Student student, Index index) {
         return notes.deleteNote(student, index.getZeroBased());
+    }
+
+    public void markClash() {
+        hasClash = true;
+    }
+
+    public void unmarkClash() {
+        hasClash = false;
     }
 }

--- a/src/main/java/jarvis/model/LessonBook.java
+++ b/src/main/java/jarvis/model/LessonBook.java
@@ -68,10 +68,9 @@ public class LessonBook implements ReadOnlyLessonBook {
     /**
      * Checks if lesson has a time period clash with existing lessons in lesson book.
      */
-    public boolean hasPeriodClash(Lesson p) {
-        return lessons.hasPeriodClash(p);
+    public boolean hasPeriodClash(Lesson l) {
+        return lessons.hasPeriodClash(l);
     }
-
 
     /**
      * Replaces the given lesson {@code targetLesson} in the list with {@code editedLesson}.

--- a/src/main/java/jarvis/model/UniqueStudentList.java
+++ b/src/main/java/jarvis/model/UniqueStudentList.java
@@ -25,7 +25,8 @@ import javafx.collections.ObservableList;
  */
 public class UniqueStudentList implements Iterable<Student> {
 
-    private static final Comparator<Student> STUDENT_COMPARATOR = Comparator.comparing(s -> s.getName().toString());
+    private static final Comparator<Student> STUDENT_COMPARATOR = Comparator.comparing(
+            s -> s.getName().toString().toLowerCase());
     private final ObservableList<Student> internalList = FXCollections.observableArrayList();
     private final ObservableList<Student> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);

--- a/src/main/java/jarvis/ui/ExpandedLessonListPanel.java
+++ b/src/main/java/jarvis/ui/ExpandedLessonListPanel.java
@@ -15,6 +15,7 @@ import javafx.scene.layout.Region;
  * Panel containing the list of lessons, fully expanded with all details shown.
  */
 public class ExpandedLessonListPanel extends UiPart<Region> {
+
     private static final String FXML = "ExpandedLessonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(ExpandedLessonListPanel.class);
 

--- a/src/main/java/jarvis/ui/LessonCard.java
+++ b/src/main/java/jarvis/ui/LessonCard.java
@@ -14,6 +14,7 @@ import javafx.scene.layout.Region;
  */
 public class LessonCard extends UiPart<Region> {
 
+    public static final String ERROR_CLASH_STYLE_CLASS = "error-clash";
     private static final String FXML = "LessonCard.fxml";
 
     /**
@@ -40,6 +41,8 @@ public class LessonCard extends UiPart<Region> {
     private Label timePeriod;
     @FXML
     private Label lessonAttendance;
+    @FXML
+    private Label hasClash;
 
     private Image tick = new Image(getClass().getResourceAsStream("/images/tick.png"));
     private Image cross = new Image(getClass().getResourceAsStream("/images/cross.png"));
@@ -50,12 +53,19 @@ public class LessonCard extends UiPart<Region> {
     public LessonCard(Lesson lesson, int displayedIndex) {
         super(FXML);
         this.lesson = lesson;
+        hasClash.textProperty().addListener((unused1, unused2, unused3) -> setStyleForClash());
+        setTextUi(displayedIndex);
+    }
+
+    private void setTextUi(int displayedIndex) {
         id.setText(displayedIndex + ". ");
+
         if (lesson.isCompleted()) {
             checkbox.setImage(tick);
         } else {
             checkbox.setImage(cross);
         }
+
         switch(lesson.getLessonType()) {
         case MASTERY_CHECK:
             lessonType.setText("Mastery Check");
@@ -72,12 +82,24 @@ public class LessonCard extends UiPart<Region> {
         default:
             assert false : "There is only 3 types of lesson";
         }
+
         if (lesson.hasDesc()) {
             lessonDesc.setText("Description: " + lesson.getDesc().lessonDesc);
         } else {
             lessonDesc.setText("{No description}");
         }
+
         timePeriod.setText(lesson.getTimePeriod().toString());
+        hasClash.setText(lesson.hasTimingConflict() ? "Clash" : "");
+    }
+
+    private void setStyleForClash() {
+        String clashText = hasClash.getText();
+        if (clashText.equals("")) {
+            cardPane.getStyleClass().remove(ERROR_CLASH_STYLE_CLASS);
+        } else if (clashText.equals("Clash")) {
+            cardPane.getStyleClass().add(ERROR_CLASH_STYLE_CLASS);
+        }
     }
 
     @Override

--- a/src/main/resources/view/ExpandedLessonCard.fxml
+++ b/src/main/resources/view/ExpandedLessonCard.fxml
@@ -42,6 +42,7 @@
            </columns>
          </TableView>
          <Label fx:id="generalNotes" style="-fx-font-size: 15; -fx-padding: 12; -fx-border-insets: 12; -fx-background-insets: 12;" styleClass="cell_small_label" text="General Notes:" />
+         <Label fx:id="hasClash" style="-fx-font-size: 15; -fx-padding: 12; -fx-border-insets: 12; -fx-background-insets: 12;" styleClass="cell_small_label" text="hasClash" visible="false" />
         </VBox>
       <rowConstraints>
          <RowConstraints />

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -18,3 +18,10 @@
 .tooltip-text {
     -fx-text-fill: white;
 }
+
+
+.error-clash {
+    -fx-background-color: #d06651 !important;
+    -fx-border-width: 1pt !important;
+    -fx-border-color: black !important;
+}

--- a/src/main/resources/view/LessonCard.fxml
+++ b/src/main/resources/view/LessonCard.fxml
@@ -28,9 +28,10 @@
                 </Label>
                 <Label fx:id="lessonType" styleClass="cell_big_label" text="\$lessonType" />
             </HBox>
-            <Label fx:id="lessonDesc" styleClass="cell_small_label" text="\$lessonDesc"/>
+            <Label fx:id="lessonDesc" styleClass="cell_small_label" text="\$lessonDesc" />
             <Label fx:id="timePeriod" styleClass="cell_small_label" text="\$timePeriod" />
             <Label fx:id="lessonAttendance" styleClass="cell_small_label" text="\$lessonAttendance" />
+         <Label fx:id="hasClash" text="hasClash" visible="false" />
         </VBox>
       <rowConstraints>
          <RowConstraints />


### PR DESCRIPTION
- Highlighting of timing conflicts in Ui
   - When user tries to add a lesson that has a timing clash with existing lesson(s), all clashing lessons will be highlighted red in the UI
- Fix bugs caused by MasteryCheck and Consult classes
  - Use TreeSet instead of HashSet to preserve alphabetical order of Students
- Change sorting of Students in student list to be case-insensitive