### PR TITLE
Fix issues mentioned in PED

### DIFF
--- a/src/main/java/jarvis/commons/core/Messages.java
+++ b/src/main/java/jarvis/commons/core/Messages.java
@@ -12,7 +12,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
     public static final String MESSAGE_INVALID_LESSON_DISPLAYED_INDEX = "The lesson index provided is invalid";
-    public static final String MESSAGE_INVALID_STUDIO_DISPLAYED_INDEX = "The studio index provided is invalid";
+    public static final String MESSAGE_INVALID_LESSON_TYPE = "The lesson at given lesson index is not a studio";
     public static final String MESSAGE_LESSONS_LISTED_OVERVIEW = "%1$d lessons listed!";
     public static final String MESSAGE_INVALID_PARTICIPATION = "The participation value provided should be an "
             + "integer from 0 to 500";

--- a/src/main/java/jarvis/logic/commands/AddParticipationCommand.java
+++ b/src/main/java/jarvis/logic/commands/AddParticipationCommand.java
@@ -28,9 +28,9 @@ public class AddParticipationCommand extends Command {
     public static final String COMMAND_WORD = "addpart";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds participation for a student in a studio. The studio is identified by its index number in the"
-            + " displayed lesson list. The student is identified using its displayed index in the student list of the "
-            + "specified studio\n"
+            + ": Adds participation for a student in a lesson. The lesson must be a studio and is identified by its "
+            + "index number in the displayed lesson list. The student is identified using its displayed index in the "
+            + "student list of the specified lesson\n"
             + "Parameters: "
             + PREFIX_PARTICIPATION + "PARTICIPATION "
             + PREFIX_LESSON_INDEX + "LESSON_INDEX "
@@ -64,7 +64,7 @@ public class AddParticipationCommand extends Command {
 
         Lesson lessonToMark = lastShownLessonList.get(lessonIndex.getZeroBased());
         if (!(lessonToMark instanceof Studio)) {
-            throw new CommandException(Messages.MESSAGE_INVALID_STUDIO_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_LESSON_TYPE);
         }
 
         Studio studioToMark = (Studio) lessonToMark;


### PR DESCRIPTION
- Change error message when `addpart` is called on a lesson that is not a studio
- Change phrasing to be clear that lesson indexes are based on lesson list (not a seperate studio list)

Fixes #137 