### PR TITLE
Set format for time input

### DIFF
--- a/src/main/java/jarvis/logic/parser/ParserUtil.java
+++ b/src/main/java/jarvis/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashSet;
@@ -30,6 +31,8 @@ public class ParserUtil {
     public static final String MESSAGE_INVALID_MARK = "Mark has to be a non-negative number.";
     public static final String MESSAGE_INVALID_MCNUM = "Mastery check number has to be 1 or 2.";
     public static final String MESSAGE_INVALID_MCRESULT = "Mastery check result has to be \"PASS\" or \"FAIL\"";
+
+    public static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -206,7 +209,7 @@ public class ParserUtil {
         requireNonNull(time);
 
         try {
-            return LocalTime.parse(time.trim());
+            return LocalTime.parse(time.trim(), TIME_FORMATTER);
         } catch (DateTimeParseException e) {
             throw new ParseException(TimePeriod.MESSAGE_CONSTRAINTS_TIME);
         }


### PR DESCRIPTION
Currently, the user can specify seconds for time inputs. This is inconsistent with existing documentation and leads to a bug where a lesson is displayed as having the same start and end time.

This PR specifies the format for time inputs to be `HH:mm`.

Fixes #142